### PR TITLE
Add 'cd mc-questing-mod-localizer' step to installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ This application supports [FTB Quests](https://www.curseforge.com/minecraft/mc-m
 ```bash
 $ git clone https://github.com/peunsu/mc-questing-mod-localizer
 ```
+* Change directory:
+```bash
+$ cd mc-questing-mod-localizer
+```
 * Create the virtual environment (optional):
 ```bash
 $ python -m venv venv


### PR DESCRIPTION
This pull request updates the installation instructions to include a step for changing into the cloned repository directory before running `pip install -r requirements.txt`.

Previously, the guide suggested running the install command immediately after cloning, which could be confusing for new users. By explicitly adding the `cd <repository-folder>` command, the instructions become clearer and more user-friendly.

Thank you for considering this improvement!